### PR TITLE
Update ``manylinux_2_28`` images

### DIFF
--- a/.github/workflows/manylinux_2_28-build+deploy.yaml
+++ b/.github/workflows/manylinux_2_28-build+deploy.yaml
@@ -12,18 +12,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     name: Build & deploy ``manylinux_2_28`` images
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { platform: linux/amd64, arch: x86_64  }
-          - { platform: linux/arm64, arch: aarch64 }
+          - { platform: linux/amd64, arch: x86_64,  runner: ubuntu-24.04     }
+          - { platform: linux/arm64, arch: aarch64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.runner }}
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Docker meta
         id: meta
@@ -63,9 +63,9 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
       -
         name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digest-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -77,10 +77,11 @@ jobs:
     steps:
       -
         name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digest-*
           path: /tmp/digests
+          merge-multiple: true
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/manylinux_2_28/aarch64/Dockerfile
+++ b/manylinux_2_28/aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux_2_28_aarch64:2023-10-22-409125c
+FROM quay.io/pypa/manylinux_2_28_aarch64:2025-05-16-b59c0c7
 
 RUN yum -y install chrpath cmake git libtool \
   && yum -y clean all \
@@ -11,7 +11,7 @@ RUN mkdir -p /yaml/build \
  && tar zxf 0.8.0.tar.gz \
  && pushd build \
  && export CXXFLAGS="-O2 -g -fPIC -DPIC" \
- && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=on ../yaml-cpp-0.8.0 \
+ && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=on -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../yaml-cpp-0.8.0 \
  && make -j4 \
  && make install \
  && popd \
@@ -33,17 +33,17 @@ RUN mkdir /gsl \
 
 # python version-dependent part
 
-ARG PYTHON_VERSIONS="3.10"
+ARG PYTHON_VERSIONS="3.10 3.11 3.12 3.13"
 
 # install boost
 #  - fix bug when linking against boost/phoenix
 RUN mkdir /boost \
  && pushd /boost \
- && curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz \
- && tar zxf /boost/boost_1_83_0.tar.gz \
- && pushd boost_1_83_0 \
+ && curl -L -O https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz \
+ && tar zxf /boost/boost_1_88_0.tar.gz \
+ && pushd boost_1_88_0 \
  && sed -i -e '/^#include <boost\/phoenix\/stl\/tuple\.hpp/d' boost/phoenix/stl.hpp \
- && ./bootstrap.sh --with-python=$PYTHON --with-libraries=filesystem,system \
+ && ./bootstrap.sh --with-python=$PYTHON --with-libraries=filesystem,math,system \
  && ./b2 install --build-type=minimal --prefix=/usr \
  && for pyver in ${PYTHON_VERSIONS} ; do \
       export PYTHON=/usr/local/bin/python${pyver} ; \

--- a/manylinux_2_28/x86_64/Dockerfile
+++ b/manylinux_2_28/x86_64/Dockerfile
@@ -1,15 +1,16 @@
-FROM quay.io/pypa/manylinux_2_28_x86_64:2023-10-22-409125c
+FROM quay.io/pypa/manylinux_2_28_x86_64:2025-05-16-b59c0c7
 
 RUN yum -y install chrpath cmake git gsl gsl-devel libtool
 
 # installation destination of the pkg-config file is hardcoded to /usr/lib/pkgconfig
+#  - using -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to avoid https://github.com/jbeder/yaml-cpp/issues/1352
 RUN mkdir -p /yaml/build \
  && pushd /yaml \
  && curl -L -O https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz \
  && tar zxf 0.8.0.tar.gz \
  && pushd build \
  && export CXXFLAGS="-O2 -g -march=x86-64 -fPIC -DPIC" \
- && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=on ../yaml-cpp-0.8.0 \
+ && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DBUILD_SHARED_LIBS=on -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../yaml-cpp-0.8.0 \
  && make -j2 \
  && make install \
  && popd \
@@ -31,17 +32,17 @@ RUN mkdir /gsl \
 
 # python version-dependent part
 
-ARG PYTHON_VERSIONS="3.9 3.10 3.11 3.12"
+ARG PYTHON_VERSIONS="3.10 3.11 3.12 3.13"
 
 # install boost
 #  - fix bug when linking against boost/phoenix
 RUN mkdir /boost \
  && pushd /boost \
- && curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz \
- && tar zxf /boost/boost_1_83_0.tar.gz \
- && pushd boost_1_83_0 \
+ && curl -L -O https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz \
+ && tar zxf /boost/boost_1_88_0.tar.gz \
+ && pushd boost_1_88_0 \
  && sed -i -e '/^#include <boost\/phoenix\/stl\/tuple\.hpp/d' boost/phoenix/stl.hpp \
- && ./bootstrap.sh --with-python=$PYTHON --with-libraries=filesystem,system \
+ && ./bootstrap.sh --with-python=$PYTHON --with-libraries=filesystem,math,system \
  && ./b2 install --build-type=minimal --prefix=/usr \
  && for pyver in ${PYTHON_VERSIONS} ; do \
       export PYTHON=/usr/local/bin/python${pyver} ; \


### PR DESCRIPTION
- bump base image to 2025-05-16
- adapt to new CMake version when building yaml-cpp
- update Boost to version 1.88.0
- include Boost math library (issue #19)

GitHub: resolves #19